### PR TITLE
fixes issue when setting properties from $field don't set

### DIFF
--- a/InputWidget.php
+++ b/InputWidget.php
@@ -22,6 +22,14 @@ class InputWidget extends \yii\widgets\InputWidget
         isset($this->options['id'])
             ? $this->setId($this->options['id'])
             : $this->options['id'] = $this->getId();
+
+        if (is_array($this->options)) {
+            foreach($this->options as $name => $value) {
+                if (property_exists($this, $name)) {
+                    $this->$name = $value;
+                }
+            }
+        }
     }
 
     public function registerJsAsset()

--- a/InputWidget.php
+++ b/InputWidget.php
@@ -22,14 +22,6 @@ class InputWidget extends \yii\widgets\InputWidget
         isset($this->options['id'])
             ? $this->setId($this->options['id'])
             : $this->options['id'] = $this->getId();
-
-        if (is_array($this->options)) {
-            foreach($this->options as $name => $value) {
-                if (property_exists($this, $name)) {
-                    $this->$name = $value;
-                }
-            }
-        }
     }
 
     public function registerJsAsset()

--- a/widgets/ActiveField.php
+++ b/widgets/ActiveField.php
@@ -84,14 +84,24 @@ class ActiveField extends \yii\widgets\ActiveField
     public function dropDownList($items, $options = [])
     {
         $multiple = ArrayHelper::remove($options, 'multiple', false);
+        $upward = ArrayHelper::remove($options, 'upward', false);
+        $compact = ArrayHelper::remove($options, 'compact', false);
+        $disabled = ArrayHelper::remove($options, 'disabled', false);
+        $fluid = ArrayHelper::remove($options, 'fluid', false);
+        $search = ArrayHelper::remove($options, 'search', true);
+
         $this->parts['{input}'] = Dropdown::widget([
             'class' => Dropdown::className(),
             'model' => $this->model,
             'attribute' => $this->attribute,
             'items' => $items,
             'options' => $options,
-            'search' => true,
-            'multiple' => $multiple
+            'search' => $search,
+            'multiple' => $multiple,
+            'upward' => $upward,
+            'compact' => $compact,
+            'disabled' => $disabled,
+            'fluid' => $fluid,
         ]);
         return $this;
     }


### PR DESCRIPTION
When using the `Dropdown` Widget regularly, you pass the values as properties to Dropdown as shown here - https://github.com/zelenin/yii2-semantic-ui/blob/master/widgets/ActiveField.php#L87

When you use `dropdownList` as part of a field in a form, all those options are passed into `$options` which is never set to the properties therefore you can't use disabled/search/etc.

To replicate

```
<?= $form->field($model, 'foo')->dropDownList(['test' => 'foo'], ['disabled' => true]); ?>
```

The field won't be disabled. 

Not sure if this is the best fix or moving the change to the individual classes like Dropdown
