### PR TITLE
added inputTemplate attribute

### DIFF
--- a/widgets/ActiveField.php
+++ b/widgets/ActiveField.php
@@ -23,9 +23,23 @@ class ActiveField extends \yii\widgets\ActiveField
     public $template = "{label}\n{input}\n{hint}\n{error}";
     public $checkboxTemplate = '<div class="ui checkbox">{input}{label}{hint}{error}</div>';
 
+    /**
+     * @var string|null optional template to render the `{input}` placeholder content
+     */
+    public $inputTemplate;
+
     public function render($content = null)
     {
         $this->registerStyles();
+
+        if ($content === null) {
+            if ($this->inputTemplate) {
+                $input = isset($this->parts['{input}']) ?
+                    $this->parts['{input}'] : Html::activeTextInput($this->model, $this->attribute, $this->inputOptions);
+                $this->parts['{input}'] = strtr($this->inputTemplate, ['{input}' => $input]);
+            }
+        }
+
         return parent::render($content);
     }
 


### PR DESCRIPTION
I've ported inputTemplate from yii2-bootstrap/Activefield. This feature is useful to change the template when using Activeform.
For example:

`<?= $form->field($model, 'username',[
                    'inputTemplate' =>"<div class='ui left icon input'>". Elements::icon('user')."{input}</div>",
                    'options' => ['class'=>'field']
                ])->textInput(['maxlength' => 255, 'placeholder'=>'Username']
                ) ?>`