### PR TITLE
Use bower alias

### DIFF
--- a/assets/SemanticUICSSAsset.php
+++ b/assets/SemanticUICSSAsset.php
@@ -10,7 +10,7 @@ class SemanticUICSSAsset extends AssetBundle
     /**
      * @var string
      */
-    public $sourcePath = '@vendor/bower/semantic/dist';
+    public $sourcePath = '@bower/semantic/dist';
 
     public function init()
     {


### PR DESCRIPTION
The directory of bower has changed and breaks the installation of Semantic, the alias is needed to correct it.