### PR TITLE
Use bower alias

### DIFF
--- a/assets/SemanticUIJSAsset.php
+++ b/assets/SemanticUIJSAsset.php
@@ -10,7 +10,7 @@ class SemanticUIJSAsset extends AssetBundle
     /**
      * @var string
      */
-    public $sourcePath = '@vendor/bower/semantic/dist';
+    public $sourcePath = '@bower/semantic/dist';
 
     /**
      * @var array


### PR DESCRIPTION
The directory of bower has changed and breaks the installation of Semantic, the alias is needed to correct it.